### PR TITLE
pfcp: relay UPF-initiated session reports, so a paged UE can be reached

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,10 @@ type UPFStatus int
 
 const MaxUpfProbeRetryInterval time.Duration = 5 // Seconds
 
+// PfcpPort mirrors udp.PFCP_PORT. It is repeated rather than imported because the udp
+// package imports this one.
+const PfcpPort = 8805
+
 var UpfCfg Config
 
 const (
@@ -157,6 +161,120 @@ func ActivateUpfNode(nodeId *types.NodeID) *UPNode {
 	}
 	logger.CfgLog.Errorf("upf node [%v] not found ", nodeId)
 	return nil
+}
+
+var (
+	smfAddrMutex sync.RWMutex
+	smfAddr      string
+
+	reportRelayMutex sync.Mutex
+	reportRelays     = make(map[uint32]reportRelay)
+	reportRelaySeq   uint32
+)
+
+const (
+	// reportRelayLifetime bounds how long the origin of a relayed report is remembered. An
+	// SMF that never answers must not cost an entry for the life of the process.
+	reportRelayLifetime = 30 * time.Second
+
+	// relaySequenceFloor is where the adapter's own sequence numbers start. Sequence
+	// numbers are three octets, and the SMF counts up from zero, so counting down from the
+	// top keeps the two apart for the life of any real deployment.
+	relaySequenceFloor = 0x800000
+	relaySequenceCeil  = 0xFFFFFF
+)
+
+type reportRelay struct {
+	upfAddr  *net.UDPAddr
+	upfSeq   uint32
+	recorded time.Time
+}
+
+// SetSmfAddr records where the SMF talks to us from. Every SMF-initiated message
+// carries it, and it is the only way the adapter can relay a message the user-plane
+// function originates: those arrive with no request of ours to answer.
+func SetSmfAddr(ip string) {
+	if ip == "" {
+		return
+	}
+
+	smfAddrMutex.Lock()
+	defer smfAddrMutex.Unlock()
+
+	if smfAddr != ip {
+		logger.CfgLog.Infof("SMF address for relayed messages is now [%s]", ip)
+	}
+
+	smfAddr = ip
+}
+
+// SmfAddr returns the recorded SMF address, or nil if no SMF has spoken to us yet.
+func SmfAddr() *net.UDPAddr {
+	smfAddrMutex.RLock()
+	defer smfAddrMutex.RUnlock()
+
+	if smfAddr == "" {
+		return nil
+	}
+
+	ip := net.ParseIP(smfAddr)
+	if ip == nil {
+		logger.CfgLog.Errorf("recorded SMF address [%s] is not an IP", smfAddr)
+		return nil
+	}
+
+	return &net.UDPAddr{IP: ip, Port: PfcpPort}
+}
+
+// RelayReportSequence allocates the sequence number the adapter uses toward the SMF for a
+// report a user-plane function raised, and remembers the origin so the answer can be
+// returned to it carrying the number it is waiting for.
+//
+// The adapter has to number these itself. Outstanding requests are held in one table
+// keyed by this socket's own address, so every request the adapter sends shares a single
+// sequence space -- forwarding a UPF's number into it is refused as a duplicate whenever
+// an SMF-originated request happens to be in flight under the same number, and the report
+// is then rejected for no reason but coincidence. With several user planes, whose counters
+// are independent of each other, two reports collide directly.
+//
+// Entries the SMF never answers are dropped once they are older than reportRelayLifetime.
+func RelayReportSequence(upfAddr *net.UDPAddr, upfSeq uint32, now time.Time) uint32 {
+	reportRelayMutex.Lock()
+	defer reportRelayMutex.Unlock()
+
+	for held, relay := range reportRelays {
+		if now.Sub(relay.recorded) > reportRelayLifetime {
+			delete(reportRelays, held)
+			logger.CfgLog.Warnf("no response was relayed for session report seq[%d], forgetting it", relay.upfSeq)
+		}
+	}
+
+	if reportRelaySeq < relaySequenceFloor || reportRelaySeq >= relaySequenceCeil {
+		reportRelaySeq = relaySequenceFloor
+	} else {
+		reportRelaySeq++
+	}
+
+	reportRelays[reportRelaySeq] = reportRelay{upfAddr: upfAddr, upfSeq: upfSeq, recorded: now}
+
+	return reportRelaySeq
+}
+
+// TakeReportRelay returns and forgets where a relayed report came from, together with the
+// sequence number that user-plane function gave it. A zero address means the response
+// matches no report the adapter relayed.
+func TakeReportRelay(relaySeq uint32) (*net.UDPAddr, uint32) {
+	reportRelayMutex.Lock()
+	defer reportRelayMutex.Unlock()
+
+	relay, ok := reportRelays[relaySeq]
+	if !ok {
+		return nil, 0
+	}
+
+	delete(reportRelays, relaySeq)
+
+	return relay.upfAddr, relay.upfSeq
 }
 
 func InsertUpfPfcpTxn(seq uint32, pfcpTxnChan PfcpTxnChan) {

--- a/config/config.go
+++ b/config/config.go
@@ -185,9 +185,11 @@ const (
 )
 
 type reportRelay struct {
+	// Ordered so the fields carrying pointers lead: govet's fieldalignment counts the leading
+	// pointer bytes, and time.Time holds one.
 	upfAddr  *net.UDPAddr
-	upfSeq   uint32
 	recorded time.Time
+	upfSeq   uint32
 }
 
 // SetSmfAddr records where the SMF talks to us from. Every SMF-initiated message
@@ -245,7 +247,11 @@ func RelayReportSequence(upfAddr *net.UDPAddr, upfSeq uint32, now time.Time) uin
 	for held, relay := range reportRelays {
 		if now.Sub(relay.recorded) > reportRelayLifetime {
 			delete(reportRelays, held)
-			logger.CfgLog.Warnf("no response was relayed for session report seq[%d], forgetting it", relay.upfSeq)
+			// Both numbers, and the peer: the map is keyed by the adapter's own sequence while the
+			// user plane is waiting on its own, and several user planes can be waiting on the same
+			// one. Reporting only the user plane's number names an entry that cannot be looked up.
+			logger.CfgLog.Warnf("no response was relayed for session report from %v: adapter seq[%d], user plane seq[%d]; forgetting it",
+				relay.upfAddr, held, relay.upfSeq)
 		}
 	}
 

--- a/config/relay_test.go
+++ b/config/relay_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// withSmfAddr isolates the package-level SMF address so ordering between tests cannot
+// decide their outcome.
+func withSmfAddr(t *testing.T, value string) {
+	t.Helper()
+
+	smfAddrMutex.Lock()
+	previous := smfAddr
+	smfAddr = value
+	smfAddrMutex.Unlock()
+
+	t.Cleanup(func() {
+		smfAddrMutex.Lock()
+		smfAddr = previous
+		smfAddrMutex.Unlock()
+	})
+}
+
+func TestSmfAddrUnknownUntilAnSmfSpeaks(t *testing.T) {
+	withSmfAddr(t, "")
+
+	if addr := SmfAddr(); addr != nil {
+		t.Fatalf("SmfAddr() = %v, want nil before any SMF message", addr)
+	}
+}
+
+func TestSetSmfAddrRecordsWhereToRelay(t *testing.T) {
+	withSmfAddr(t, "")
+
+	SetSmfAddr("10.42.0.188")
+
+	addr := SmfAddr()
+	if addr == nil {
+		t.Fatal("SmfAddr() = nil, want the recorded address")
+	}
+
+	if !addr.IP.Equal(net.ParseIP("10.42.0.188")) || addr.Port != PfcpPort {
+		t.Errorf("SmfAddr() = %v, want 10.42.0.188:%d", addr, PfcpPort)
+	}
+}
+
+// An SMF-initiated message without the field must not erase an address we already have,
+// or one malformed request would stop every later report from being relayed.
+func TestSetSmfAddrIgnoresEmpty(t *testing.T) {
+	withSmfAddr(t, "10.42.0.188")
+
+	SetSmfAddr("")
+
+	if addr := SmfAddr(); addr == nil || !addr.IP.Equal(net.ParseIP("10.42.0.188")) {
+		t.Errorf("SmfAddr() = %v, want the previously recorded address", addr)
+	}
+}
+
+func TestSmfAddrRejectsNonIP(t *testing.T) {
+	withSmfAddr(t, "upf-adapter.local")
+
+	if addr := SmfAddr(); addr != nil {
+		t.Errorf("SmfAddr() = %v, want nil for a value that is not an IP", addr)
+	}
+}
+
+// A relayed report is renumbered into the adapter's own space, and the answer must carry
+// the number the user plane is waiting for -- not the adapter's.
+func TestRelayReportSequenceKeepsTheUpfsOwnNumber(t *testing.T) {
+	upfAddr := &net.UDPAddr{IP: net.ParseIP("10.42.0.184"), Port: PfcpPort}
+
+	relaySeq := RelayReportSequence(upfAddr, 4711, time.Now())
+	if relaySeq == 4711 {
+		t.Error("the report was relayed under the UPF's own sequence number, which shares a table with the SMF's")
+	}
+
+	if relaySeq < relaySequenceFloor || relaySeq > relaySequenceCeil {
+		t.Errorf("relay sequence %#x outside the adapter's range [%#x, %#x]",
+			relaySeq, relaySequenceFloor, relaySequenceCeil)
+	}
+
+	addr, upfSeq := TakeReportRelay(relaySeq)
+	if addr == nil || !addr.IP.Equal(upfAddr.IP) || addr.Port != upfAddr.Port {
+		t.Fatalf("TakeReportRelay(%d) address = %v, want %v", relaySeq, addr, upfAddr)
+	}
+
+	if upfSeq != 4711 {
+		t.Errorf("TakeReportRelay(%d) UPF sequence = %d, want 4711", relaySeq, upfSeq)
+	}
+
+	// Taken exactly once, so a duplicate response cannot be forwarded to a stale peer.
+	if again, _ := TakeReportRelay(relaySeq); again != nil {
+		t.Errorf("TakeReportRelay(%d) second call = %v, want nil", relaySeq, again)
+	}
+}
+
+// Two user planes number their reports independently, so the same number arriving from
+// both must still resolve to the right peer.
+func TestRelayReportSequenceSeparatesTwoUpfsUsingTheSameNumber(t *testing.T) {
+	first := &net.UDPAddr{IP: net.ParseIP("10.42.0.184"), Port: PfcpPort}
+	second := &net.UDPAddr{IP: net.ParseIP("10.42.0.185"), Port: PfcpPort}
+
+	now := time.Now()
+
+	firstRelay := RelayReportSequence(first, 1, now)
+	secondRelay := RelayReportSequence(second, 1, now)
+
+	if firstRelay == secondRelay {
+		t.Fatalf("both reports were relayed as seq[%d]; one origin has been lost", firstRelay)
+	}
+
+	firstAddr, firstSeq := TakeReportRelay(firstRelay)
+	secondAddr, secondSeq := TakeReportRelay(secondRelay)
+
+	if firstAddr == nil || !firstAddr.IP.Equal(first.IP) {
+		t.Errorf("first report resolved to %v, want %v", firstAddr, first)
+	}
+
+	if secondAddr == nil || !secondAddr.IP.Equal(second.IP) {
+		t.Errorf("second report resolved to %v, want %v", secondAddr, second)
+	}
+
+	if firstSeq != 1 || secondSeq != 1 {
+		t.Errorf("restored UPF sequences = %d and %d, want 1 and 1", firstSeq, secondSeq)
+	}
+}
+
+// Sequence numbers are three octets on the wire, so the counter has to come back round
+// inside the adapter's own range rather than overflow into the SMF's.
+func TestRelayReportSequenceWrapsWithinItsOwnRange(t *testing.T) {
+	upfAddr := &net.UDPAddr{IP: net.ParseIP("10.42.0.184"), Port: PfcpPort}
+
+	reportRelayMutex.Lock()
+	previous := reportRelaySeq
+	reportRelaySeq = relaySequenceCeil
+	reportRelayMutex.Unlock()
+
+	t.Cleanup(func() {
+		reportRelayMutex.Lock()
+		reportRelaySeq = previous
+		reportRelayMutex.Unlock()
+	})
+
+	relaySeq := RelayReportSequence(upfAddr, 7, time.Now())
+	if relaySeq != relaySequenceFloor {
+		t.Errorf("sequence after the ceiling = %#x, want %#x", relaySeq, relaySequenceFloor)
+	}
+
+	TakeReportRelay(relaySeq)
+}
+
+// An SMF that never answers must not cost an entry for the life of the process.
+func TestReportRelayForgetsEntriesTheSmfNeverAnswered(t *testing.T) {
+	stale := &net.UDPAddr{IP: net.ParseIP("10.42.0.184"), Port: PfcpPort}
+	fresh := &net.UDPAddr{IP: net.ParseIP("10.42.0.185"), Port: PfcpPort}
+
+	now := time.Now()
+
+	staleRelay := RelayReportSequence(stale, 1, now.Add(-2*reportRelayLifetime))
+	freshRelay := RelayReportSequence(fresh, 2, now)
+
+	if addr, _ := TakeReportRelay(staleRelay); addr != nil {
+		t.Errorf("TakeReportRelay(%d) = %v, want nil for an entry past its lifetime", staleRelay, addr)
+	}
+
+	if addr, _ := TakeReportRelay(freshRelay); addr == nil {
+		t.Errorf("TakeReportRelay(%d) = nil, want the entry recorded just now", freshRelay)
+	}
+}
+
+func TestTakeReportRelayUnknownSequence(t *testing.T) {
+	if addr, _ := TakeReportRelay(999999); addr != nil {
+		t.Errorf("TakeReportRelay(unknown) = %v, want nil", addr)
+	}
+}

--- a/pfcp/dispatcher.go
+++ b/pfcp/dispatcher.go
@@ -6,12 +6,14 @@
 package pfcp
 
 import (
+	"net"
+
 	"github.com/omec-project/upfadapter/logger"
 	"github.com/omec-project/upfadapter/pfcp/handler"
 	"github.com/wmnsk/go-pfcp/message"
 )
 
-func Dispatch(msg message.Message) {
+func Dispatch(msg message.Message, remoteAddr *net.UDPAddr) {
 	// TODO: Add return status to all handlers
 	msgType := msg.MessageType()
 	switch msgType {
@@ -57,12 +59,13 @@ func Dispatch(msg message.Message) {
 		handler.HandlePfcpSessionModificationResponse(msg)
 	case message.MsgTypeSessionDeletionResponse:
 		handler.HandlePfcpSessionDeletionResponse(msg)
-		/*
-			case pfcp.PFCP_SESSION_REPORT_REQUEST:
-				handler.HandlePfcpSessionReportRequest(msg)
-			case pfcp.PFCP_SESSION_REPORT_RESPONSE:
-				handler.HandlePfcpSessionReportResponse(msg)
-		*/
+	// A session report is the one message on N4 that the user-plane function
+	// originates. Relaying it, and returning the SMF's answer, is what lets an idle
+	// UE be paged at all through this adapter.
+	case message.MsgTypeSessionReportRequest:
+		handler.HandlePfcpSessionReportRequest(msg, remoteAddr)
+	case message.MsgTypeSessionReportResponse:
+		handler.HandlePfcpSessionReportResponse(msg)
 	default:
 		logger.PfcpLog.Errorf("unknown pfcp message type [%d]: %s", msgType, msg.MessageTypeName())
 		return

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -5,9 +5,12 @@ package handler
 
 import (
 	"fmt"
+	"net"
+	"time"
 
 	"github.com/omec-project/upfadapter/config"
 	"github.com/omec-project/upfadapter/logger"
+	"github.com/omec-project/upfadapter/pfcp/udp"
 	"github.com/omec-project/upfadapter/types"
 	"github.com/wmnsk/go-pfcp/ie"
 	"github.com/wmnsk/go-pfcp/message"
@@ -170,6 +173,126 @@ func HandlePfcpSessionModificationResponse(msg message.Message) {
 	// Encode pfcp rsp to byte and send to http txn
 	if err := encodeAndSendRsp(msg); err != nil {
 		logger.PfcpLog.Errorf("handle pfcp session modify response error [%v]", err)
+	}
+}
+
+// HandlePfcpSessionReportRequest relays a report the user-plane function originated to
+// the SMF, and remembers where it came from so the answer can be returned.
+//
+// Nothing used to handle this message: it fell to the dispatcher's default branch and
+// was logged as unknown. A downlink data notification is the only way the SMF learns
+// that an idle UE has traffic waiting, so dropping it removed mobile-terminated
+// reachability from every deployment that puts this adapter on N4 -- silently, because
+// the user-plane function's request simply went unanswered.
+func HandlePfcpSessionReportRequest(msg message.Message, upfAddr *net.UDPAddr) {
+	report, ok := msg.(*message.SessionReportRequest)
+	if !ok {
+		logger.PfcpLog.Errorln("invalid PFCP Session Report Request")
+		return
+	}
+
+	if upfAddr == nil {
+		logger.PfcpLog.Errorln("session report request with no peer address, cannot relay or answer")
+		return
+	}
+
+	upfSeq := report.Sequence()
+
+	smfAddr := config.SmfAddr()
+	if smfAddr == nil {
+		// Answer rather than stay silent: an unanswered request leaves the user-plane
+		// function retransmitting into nothing, and a rejection at least tells it the
+		// traffic will not be delivered.
+		logger.PfcpLog.Errorln("no SMF address known yet, rejecting session report request")
+		rejectSessionReport(report.SEID(), upfSeq, upfAddr)
+
+		return
+	}
+
+	// Renumber into the adapter's own sequence space before relaying; the UPF's number
+	// goes back on the response. See config.RelayReportSequence.
+	relaySeq := config.RelayReportSequence(upfAddr, upfSeq, time.Now())
+	report.SetSequenceNumber(relaySeq)
+
+	// If the SMF never answers, tell the user-plane function so. Its own retransmissions
+	// would otherwise be the only thing that ends the wait, and TS 29.244 expects every
+	// request to be answered. TakeReportRelay is take-once, so this and the response path
+	// cannot both answer the same report.
+	seid := report.SEID()
+	eventData := udp.PfcpEventData{LSEID: 0, ErrHandler: func(sent message.Message, sendErr error) {
+		logger.PfcpLog.Errorf("relayed session report seq[%d] was not answered by the SMF: %v",
+			sent.Sequence(), sendErr)
+
+		if addr, seq := config.TakeReportRelay(sent.Sequence()); addr != nil {
+			rejectSessionReport(seid, seq, addr)
+		}
+	}}
+
+	if err := udp.SendPfcp(report, smfAddr, eventData); err != nil {
+		logger.PfcpLog.Errorf("failed to relay session report request to SMF [%v]: %v", smfAddr, err)
+		config.TakeReportRelay(relaySeq)
+		rejectSessionReport(seid, upfSeq, upfAddr)
+
+		return
+	}
+
+	logger.PfcpLog.Infof("relayed session report seq[%d] from UPF [%v] to SMF [%v] as seq[%d]",
+		upfSeq, upfAddr, smfAddr, relaySeq)
+}
+
+// HandlePfcpSessionReportResponse returns the SMF's answer to the user-plane function
+// that raised the report. Unlike the other responses this one is not the tail of an
+// SMF-initiated exchange, so there is no HTTP transaction waiting for it.
+func HandlePfcpSessionReportResponse(msg message.Message) {
+	response, ok := msg.(*message.SessionReportResponse)
+	if !ok {
+		logger.PfcpLog.Errorln("invalid PFCP Session Report Response")
+		return
+	}
+
+	relaySeq := response.Sequence()
+
+	upfAddr, upfSeq := config.TakeReportRelay(relaySeq)
+	if upfAddr == nil {
+		logger.PfcpLog.Warnf("session report response seq[%d] matches no relayed report, dropping",
+			relaySeq)
+		return
+	}
+
+	// The user-plane function is waiting for its own sequence number, not ours.
+	response.SetSequenceNumber(upfSeq)
+
+	if err := udp.SendPfcp(response, upfAddr, reportResponseEventData()); err != nil {
+		logger.PfcpLog.Errorf("failed to return session report response to UPF [%v]: %v", upfAddr, err)
+		return
+	}
+
+	logger.PfcpLog.Infof("returned session report response seq[%d] to UPF [%v]", upfSeq, upfAddr)
+}
+
+// reportResponseEventData reports the end of a response's resend window for what it is.
+// A response transaction holds the message so a retransmitted report is answered again,
+// and closes with a timeout once the peer stops asking -- the ordinary outcome of a
+// delivered response. HandlePfcpSendError would announce that as a message it was unable
+// to send, and a false negative on this path is what made the original defect so hard to
+// find.
+func reportResponseEventData() udp.PfcpEventData {
+	return udp.PfcpEventData{LSEID: 0, ErrHandler: func(msg message.Message, err error) {
+		logger.PfcpLog.Debugf("resend window closed for session report response seq[%d]: %v",
+			msg.Sequence(), err)
+	}}
+}
+
+// rejectSessionReport answers a report the adapter cannot relay, so the user-plane
+// function stops waiting and can release what it was holding. It is answered under the
+// sequence number that user plane used, which is not the one the report may since have
+// been renumbered to.
+func rejectSessionReport(seid uint64, upfSeq uint32, upfAddr *net.UDPAddr) {
+	rsp := message.NewSessionReportResponse(0, 0, seid, upfSeq, 0,
+		ie.NewCause(ie.CauseRequestRejected))
+
+	if err := udp.SendPfcp(rsp, upfAddr, reportResponseEventData()); err != nil {
+		logger.PfcpLog.Errorf("failed to reject session report request to UPF [%v]: %v", upfAddr, err)
 	}
 }
 

--- a/pfcp/udp/udp.go
+++ b/pfcp/udp/udp.go
@@ -6,6 +6,7 @@
 package udp
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -40,6 +41,12 @@ type PfcpServer struct {
 }
 
 var Server *PfcpServer
+
+// ErrResendRequest reports that a peer retransmitted a request the adapter is already
+// answering, which is ordinary and not a read failure. It was previously compared by
+// message text, in a spelling the text never had, so every retransmission was logged as
+// an error -- unnoticed while no user-plane-originated request was handled at all.
+var ErrResendRequest = errors.New("receive resend PFCP request")
 
 var (
 	ServerStartTime time.Time
@@ -122,49 +129,52 @@ func SendPfcp(msg message.Message, addr *net.UDPAddr, eventData interface{}) err
 	return nil
 }
 
-func readPfcpMessage() (message.Message, error) {
+// readPfcpMessage returns the peer address alongside the message. A message the
+// user-plane function originates -- a session report -- has to be answered and
+// relayed, and neither is possible without knowing who sent it.
+func readPfcpMessage() (message.Message, *net.UDPAddr, error) {
 	if Server == nil {
-		return nil, fmt.Errorf("PFCP server is not initialized")
+		return nil, nil, fmt.Errorf("PFCP server is not initialized")
 	}
 	if Server.Conn == nil {
-		return nil, fmt.Errorf("PFCP server is not listening")
+		return nil, nil, fmt.Errorf("PFCP server is not listening")
 	}
 
 	buf := make([]byte, PFCP_MAX_UDP_LEN)
 	n, addr, err := Server.Conn.ReadFromUDP(buf)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	msg, err := message.Parse(buf[:n])
 	if err != nil {
 		logger.PfcpLog.Errorf("error parsing PFCP message: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	if IsRequest(msg) {
 		// Todo: Implement SendingResponse type of reliable delivery
 		tx, err := findTransaction(msg, addr)
 		if err != nil {
-			return msg, err
+			return msg, addr, err
 		} else if tx != nil {
 			// err == nil && tx != nil => Resend Request
-			err = fmt.Errorf("receive resend PFCP request")
+			err = ErrResendRequest
 			tx.EventChannel <- ReceiveResendRequest
-			return msg, err
+			return msg, addr, err
 		} else {
 			// err == nil && tx == nil => New Request
-			return msg, nil
+			return msg, addr, nil
 		}
 	} else if IsResponse(msg) {
 		tx, err := findTransaction(msg, Server.Addr)
 		if err != nil {
-			return msg, err
+			return msg, addr, err
 		}
 		tx.EventChannel <- ReceiveValidResponse
 	}
 
-	return msg, nil
+	return msg, addr, nil
 }
 
 func findTransaction(msg message.Message, addr *net.UDPAddr) (*Transaction, error) {
@@ -202,7 +212,7 @@ func findTransaction(msg message.Message, addr *net.UDPAddr) (*Transaction, erro
 	return tx, nil
 }
 
-func Run(Dispatch func(message.Message)) {
+func Run(Dispatch func(message.Message, *net.UDPAddr)) {
 	addr := &net.UDPAddr{
 		IP:   net.ParseIP(CPNodeID.ResolveNodeIdToIp().String()),
 		Port: PFCP_PORT,
@@ -220,16 +230,16 @@ func Run(Dispatch func(message.Message)) {
 
 	go func() {
 		for {
-			pfcpMessage, err := readPfcpMessage()
+			pfcpMessage, remoteAddr, err := readPfcpMessage()
 			if err != nil {
-				if err.Error() == "Receive resend PFCP request" {
+				if errors.Is(err, ErrResendRequest) {
 					logger.PfcpLog.Infoln(err)
 				} else {
 					logger.PfcpLog.Warnf("read PFCP error: %v", err)
 				}
 				continue
 			}
-			go Dispatch(pfcpMessage)
+			go Dispatch(pfcpMessage, remoteAddr)
 		}
 	}()
 

--- a/upfadapter.go
+++ b/upfadapter.go
@@ -44,6 +44,10 @@ func handler(w http.ResponseWriter, req *http.Request) {
 	logger.AppLog.Debugf("received msg type [%v], upf nodeId [%s], smfIp [%v], msg [%v]",
 		pfcpMessage.MessageType(), udpPodMsg.UpNodeID.NodeIdValue, udpPodMsg.SmfIp, udpPodMsg.Msg)
 
+	// Remember where the SMF is. A message the user-plane function originates arrives
+	// with no request of ours to answer, so this is the only address we can relay it to.
+	config.SetSmfAddr(udpPodMsg.SmfIp)
+
 	pfcpJsonRsp, err := pfcp.ForwardPfcpMsgToUpf(pfcpMessage, udpPodMsg.UpNodeID)
 	if err != nil {
 		logger.AppLog.Errorf("error forwarding pfcp msg to UPF: %v", err)

--- a/upfadapter.go
+++ b/upfadapter.go
@@ -8,6 +8,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"os"
 
@@ -46,6 +47,23 @@ func handler(w http.ResponseWriter, req *http.Request) {
 
 	// Remember where the SMF is. A message the user-plane function originates arrives
 	// with no request of ours to answer, so this is the only address we can relay it to.
+	//
+	// The address is taken from the body rather than from the connection, and the mismatch
+	// is reported rather than refused. The SMF fills it with its own first non-loopback
+	// address, which is the peer address in an ordinary deployment -- but not necessarily
+	// one where the SMF is multi-homed or reached through a proxy, and refusing there would
+	// break the relay for a difference that is legitimate. A claim that does not match the
+	// peer is worth seeing, so it is logged once per change.
+	if host, _, splitErr := net.SplitHostPort(req.RemoteAddr); splitErr == nil &&
+		udpPodMsg.SmfIp != "" && udpPodMsg.SmfIp != host {
+		// Only when the claim changes. Every PFCP message the SMF sends arrives here, so a
+		// persistent mismatch would otherwise warn on each one.
+		if current := config.SmfAddr(); current == nil || current.IP.String() != udpPodMsg.SmfIp {
+			logger.AppLog.Warnf("message claims SMF address [%s] but arrived from [%s]; relaying to the claimed address",
+				udpPodMsg.SmfIp, host)
+		}
+	}
+
 	config.SetSmfAddr(udpPodMsg.SmfIp)
 
 	pfcpJsonRsp, err := pfcp.ForwardPfcpMsgToUpf(pfcpMessage, udpPodMsg.UpNodeID)


### PR DESCRIPTION
### What this fixes

A Session Report is the only message on N4 that the **user-plane function** originates, and a
downlink data report is the only way the SMF learns that an idle UE has traffic waiting. This
adapter handles neither — types 56 and 57 are commented out of the dispatcher, so a report falls
through to the default branch and is logged as an unknown message type:

```go
        /*
                case pfcp.PFCP_SESSION_REPORT_REQUEST:
                        handler.HandlePfcpSessionReportRequest(msg)
                case pfcp.PFCP_SESSION_REPORT_RESPONSE:
                        handler.HandlePfcpSessionReportResponse(msg)
        */
```

There is no UPF→SMF direction here at all. The consequence is that **any deployment putting this
adapter on N4 has no mobile-terminated reachability**: a downlink packet for an idle UE never
becomes a page. It fails silently, twice over — the SMF never learns there is traffic waiting,
and the user plane's request is never answered, so it retransmits into nothing while holding
traffic it should either deliver or release.

### What the relay does

- The dispatcher routes types 56 and 57, and the read path returns the peer address — without
  which a UPF-originated message can be neither answered nor attributed.
- The SMF's address is recorded from the SMF-initiated messages that already carry it (`SmfIp`),
  since a relayed report has no request of ours to answer.
- The report is **renumbered into the adapter's own sequence space**, and the user plane's own
  number is restored on the response. This is the part worth a second look: outstanding requests
  are held in one table keyed by this socket's own address, so every request the adapter sends
  shares a single sequence space. Forwarding a UPF's number into it is refused as a duplicate
  whenever an SMF-originated request happens to be in flight under the same number — and the
  report is then rejected for no reason but coincidence. With several user planes, whose counters
  are independent, two reports collide with each other directly and one origin is lost.
- A report that cannot be relayed is **rejected rather than dropped**, including when the SMF
  never answers, so the user plane always learns the outcome instead of retransmitting blind.
  The recorded origin is forgotten after 30 s, so an unanswered report costs nothing lasting.

### Two smaller things this made necessary

- A response sent to a user plane keeps its own error handler. The resend transaction ends in a
  timeout once the peer stops retransmitting — the ordinary outcome of a *delivered* response —
  and `HandlePfcpSendError` announced that as a message it had been unable to send.
- The retransmission check compared an error against a spelling that error never had
  (`"Receive resend PFCP request"` vs `"receive resend PFCP request"`), so every retransmission
  was logged as a read failure. Harmless while no user-plane-originated request was handled at
  all; reachable now, so it is replaced with a sentinel and `errors.Is`.

### Testing

`linux/amd64`, in the images CI pins:

- `go test -race ./...` green in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

Unit tests cover the bookkeeping: the address is remembered and an empty one does not erase it,
the origin is taken exactly once, two user planes using the same number stay distinguishable, the
counter wraps inside its own range, and entries the SMF never answered age out.

Verified end to end on a live deployment with `enableUPFAdapter: true`. A downlink packet to an
idle UE produced:

```
20:03:02.446  UPF -> adapter   Session Report Request  seq[1]
20:03:02.447  adapter -> SMF   Session Report Request  seq[8388608]   <- adapter's own range
20:03:02.456  SMF -> adapter   Session Report Response seq[8388608]   Cause: Request accepted
20:03:02.4560 Paging on N2
20:03:02.4572 adapter -> UPF   Session Report Response seq[1]         <- the peer's own number
20:03:02.4636 Service request
```

and the UE's user plane restored 18 ms after the page, where before the report was dropped.

### Note for reviewers

The `PfcpPort` constant is duplicated in `config` rather than imported from `udp`, because `udp`
imports `config`. If you would rather have it moved somewhere both can import, say so and I will
restructure.
